### PR TITLE
fix: turned on facts for control role, fix indents

### DIFF
--- a/ansible/main.yaml
+++ b/ansible/main.yaml
@@ -7,7 +7,7 @@
 
 - name: Kubernetes Control Plane
   hosts: kubernetes_control_nodes
-  gather_facts: false
+  gather_facts: true
   roles:
   - role: kubernetes-control
     kube_api_server_vip: 192.168.1.220

--- a/ansible/roles/ubuntu-baseline/handlers/main.yaml
+++ b/ansible/roles/ubuntu-baseline/handlers/main.yaml
@@ -6,4 +6,4 @@
   service:
     name: systemd-timesyncd
     state: restarted
-    listen: "restart timesyncd"
+  listen: "restart timesyncd"


### PR DESCRIPTION
- Turned on fact lookup for role `kubernetes-control`, facts are needed to inform `ansible_default_ipv4`
- Fixed bad indents in timesyncd handler